### PR TITLE
Revert "Documentation fix for uninstallation"

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,10 +1,7 @@
 # Installation
 
-1. Upload the module to /protected/modules (or another module path)
+1. Upload the module to /protected/modules (or another module loader path) OR use 'git clone https://github.com/felixhahnweilheim/humhub-themes-orange.git'
 2. Enable the module in Administration > Modules
 2. Select the theme at Administration > Settings > Appearance (save at the bottom)
 
 If you try out the theme with another HumHub version than 1.10, please rebuild css/theme.css (see the [HumHub Theming guide](https://docs.humhub.org/docs/theme/css#compile-css-package)).
-
-## Deactivating / Deleting
-To be sure everything works correctly, I first choose the Community theme in Administration > Settings > Appearance (save at the bottom) and then deactivate the module. Then you can also safely delete the module.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,6 +7,4 @@
 If you try out the theme with another HumHub version than 1.10, please rebuild css/theme.css (see the [HumHub Theming guide](https://docs.humhub.org/docs/theme/css#compile-css-package)).
 
 ## Deactivating / Deleting
-To be sure everything works correctly, I first choose the Community theme in Administration > Settings > Appearance (save at the bottom) and then deactivate the module.
-
-To remove the module please go to `/protected` and execute `php yii module/remove 'humhub-themes-orange'`
+To be sure everything works correctly, I first choose the Community theme in Administration > Settings > Appearance (save at the bottom) and then deactivate the module. Then you can also safely delete the module.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,7 +1,7 @@
 # Installation
 
-1. Upload the module to /protected/modules (or another module loader path) OR use 'git clone https://github.com/felixhahnweilheim/humhub-themes-orange.git'
+1. Upload the module to /protected/modules (or another module loader path) OR use `git clone https://github.com/felixhahnweilheim/humhub-themes-orange.git`
 2. Enable the module in Administration > Modules
 2. Select the theme at Administration > Settings > Appearance (save at the bottom)
 
-If you try out the theme with another HumHub version than 1.10, please rebuild css/theme.css (see the [HumHub Theming guide](https://docs.humhub.org/docs/theme/css#compile-css-package)).
+If you try out the theme with another HumHub version than 1.10, please rebuild the css file (`themes/themeOrange/css/theme.css`) (see the [HumHub Theming guide](https://docs.humhub.org/docs/theme/css#compile-css-package)).

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,7 @@ This is a child [theme module](https://docs.humhub.org/docs/theme/module#theme-m
 **Author:** Felix Hahn, info@hahn-felix.de - self-learned, hobbyist
 
 ## State of development
-I tried to exactly follow the official theming documentation and it works fine in my HumHub installation. But I have not tested all possible settings and available modules.
-
+The theme works fine in my HumHub installation, but I have not tested all possible settings and available modules.
 That's why I recommend you to test the module with your settings, modules etc. and/or look through my code before activating it on a production site.
 
 Please give me some feedback how it works for you.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ This is a child [theme module](https://docs.humhub.org/docs/theme/module#theme-m
 ## State of development
 I tried to exactly follow the official theming documentation and it works fine in my HumHub installation. But I have not tested all possible settings and available modules.
 
-That's why I recommend you to test the module with your settings, modules etc. and/or look through my code before activating it on a production site. **Please note:** Currently you have to remove the module manually as [described here](https://github.com/felixhahnweilheim/humhub-themes-orange/blob/doc-fix-for-uninstallation/docs/INSTALLATION.md#deactivating--deleting).
+That's why I recommend you to test the module with your settings, modules etc. and/or look through my code before activating it on a production site.
 
 Please give me some feedback how it works for you.
 


### PR DESCRIPTION
Reverts felixhahnweilheim/humhub-themes-orange#2

The error only occured because the uploaded module was owned by root but it should have been www-data.