### PR TITLE
Fix enable other module

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -11,26 +11,7 @@ use yii\helpers\Url;
 
 class Events
 {
-    /*
-     * Callback after Module enabled
-     * @param ModuleEvent $event
-     */
-    public static function onModuleEnabled($event)
-    {
-        /*Activate Orange Theme*/
-        $theme = ThemeHelper::getThemeByName('themeOrange');
-        if ($theme !== null) {
-            $theme->activate();
-        }
-		
-		/*Add Module settings*/
-		$module = Yii::$app->getModule('theme-orange');
-		$module->settings->set('commentLink', $module->commentLink);
-	    $module->settings->set('likeLink', $module->likeLink);
-		$module->settings->set('likeIcon', $module->likeIcon);
-    }
-    
-	public static function onAdminMenuInit($event)
+    public static function onAdminMenuInit($event)
     {
 		$event->sender->addItem([
             'label' =>  Yii::t('ThemeOrangeModule.base', 'Theme Orange Configuration'),

--- a/Module.php
+++ b/Module.php
@@ -4,6 +4,7 @@ namespace humhub\modules\themeOrange;
 
 use humhub\modules\ui\view\helpers\ThemeHelper;
 use humhub\models\Setting;
+use humhub\libs\DynamicConfig;
 use Yii;
 use yii\helpers\Url;
 

--- a/Module.php
+++ b/Module.php
@@ -28,6 +28,8 @@ class Module extends \humhub\components\Module
 	 * @var string defines the like icon (options: heart, thumbsup, star)
 	 */
 	public $likeIcon = 'heart';
+    
+    const THEME_NAME = "themeOrange";
 	
 	public static function getCommentLinkSetting() {
 		return Yii::$app->getModule('theme-orange')->settings->get('commentLink');
@@ -54,6 +56,38 @@ class Module extends \humhub\components\Module
 	public function getDescription() {
         return Yii::t('ThemeOrangeModule.base', 'A child theme for HumHub');
     }
+
+    public function enable() {
+    
+	    /*Add Module settings*/
+		$module = Yii::$app->getModule('theme-orange');
+		$module->settings->set('commentLink', $module->commentLink);
+	    $module->settings->set('likeLink', $module->likeLink);
+		$module->settings->set('likeIcon', $module->likeIcon);
+        
+        if (parent::enable()) {
+            $this->enableTheme();
+            return true;
+        }
+        return false;
+    }
+    
+    private function enableTheme()
+    {
+        // Already a theme based theme is active
+        foreach (ThemeHelper::getThemeTree(Yii::$app->view->theme) as $theme) {
+            if ($theme->name === self::THEME_NAME) {
+                return;
+            }
+        }
+
+        $theme = ThemeHelper::getThemeByName(self::THEME_NAME);
+        if ($theme !== null) {
+            $theme->activate();
+            DynamicConfig::rewrite();
+        }
+    }
+    
 	/**
 	 * @inheritdoc
 	 */

--- a/Module.php
+++ b/Module.php
@@ -31,8 +31,12 @@ class Module extends \humhub\components\Module
     
     const THEME_NAME = "themeOrange";
 	
-	public static function getCommentLinkSetting() {
-		return Yii::$app->getModule('theme-orange')->settings->get('commentLink');
+    public static function getCommentLinkSetting() {
+		$commentLink = Yii::$app->getModule('theme-orange')->settings->get('commentLink');
+        if (empty($commentLink) {
+            $commentLink = $this->commentLink;
+        }
+        return $commentLink;
 	}
 	
 	public static function getLikeLinkSetting() {

--- a/Module.php
+++ b/Module.php
@@ -39,12 +39,20 @@ class Module extends \humhub\components\Module
         return $commentLink;
 	}
 	
-	public static function getLikeLinkSetting() {
-		return Yii::$app->getModule('theme-orange')->settings->get('likeLink');
+    public static function getLikeLinkSetting() {
+		$likeLink = Yii::$app->getModule('theme-orange')->settings->get('likeLink');
+        if (empty($likeLink) {
+            $likeLink = $this->likeLink;
+        }
+        return $likeLink;
 	}
 	
 	public static function getLikeIcon() {
-		return Yii::$app->getModule('theme-orange')->settings->get('likeIcon');
+		$likeIcon = Yii::$app->getModule('theme-orange')->settings->get('likeIcon');
+        if (empty($likeIcon) {
+            $likeIcon = $this->likeIcon
+        }
+        return $likeIcon;
 	}
 	
 	/*
@@ -63,12 +71,6 @@ class Module extends \humhub\components\Module
 
     public function enable() {
     
-	    /*Add Module settings*/
-		$module = Yii::$app->getModule('theme-orange');
-		$module->settings->set('commentLink', $module->commentLink);
-	    $module->settings->set('likeLink', $module->likeLink);
-		$module->settings->set('likeIcon', $module->likeIcon);
-        
         if (parent::enable()) {
             $this->enableTheme();
             return true;

--- a/Module.php
+++ b/Module.php
@@ -33,7 +33,7 @@ class Module extends \humhub\components\Module
 	
     public static function getCommentLinkSetting() {
 		$commentLink = Yii::$app->getModule('theme-orange')->settings->get('commentLink');
-        if (empty($commentLink) {
+        if (empty($commentLink)) {
             $commentLink = $this->commentLink;
         }
         return $commentLink;
@@ -41,7 +41,7 @@ class Module extends \humhub\components\Module
 	
     public static function getLikeLinkSetting() {
 		$likeLink = Yii::$app->getModule('theme-orange')->settings->get('likeLink');
-        if (empty($likeLink) {
+        if (empty($likeLink)) {
             $likeLink = $this->likeLink;
         }
         return $likeLink;
@@ -49,7 +49,7 @@ class Module extends \humhub\components\Module
 	
 	public static function getLikeIcon() {
 		$likeIcon = Yii::$app->getModule('theme-orange')->settings->get('likeIcon');
-        if (empty($likeIcon) {
+        if (empty($likeIcon)) {
             $likeIcon = $this->likeIcon
         }
         return $likeIcon;

--- a/Module.php
+++ b/Module.php
@@ -50,7 +50,7 @@ class Module extends \humhub\components\Module
 	public static function getLikeIcon() {
 		$likeIcon = Yii::$app->getModule('theme-orange')->settings->get('likeIcon');
         if (empty($likeIcon)) {
-            $likeIcon = $this->likeIcon
+            $likeIcon = $this->likeIcon;
         }
         return $likeIcon;
 	}

--- a/config.php
+++ b/config.php
@@ -10,15 +10,10 @@ return [
     'class' => 'humhub\modules\themeOrange\Module',
     'namespace' => 'humhub\modules\themeOrange',
     'events' => [
-		[
-			'class' => ModuleManager::class,
-			'event' => ModuleManager::EVENT_AFTER_MODULE_ENABLE,
-			'callback' => [Events::class, 'onModuleEnabled']
-		],
-		[
-			'class' => AdminMenu::class,
-			'event' => AdminMenu::EVENT_INIT,
-			'callback' => [Events::class, 'onAdminMenuInit']
-		],
+	[
+	    'class' => AdminMenu::class,
+	    'event' => AdminMenu::EVENT_INIT,
+	    'callback' => [Events::class, 'onAdminMenuInit']
 	],
+    ],
 ];

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,6 @@
+## TBA
+- Fix: theme was activated when another module was enabled
+
 ## 0.6.0 (March 11 2023)
 - Enh: add configuration page (replace file configuration) - NOTE: Please remove file configuration and select your settings in the new administration page
 - Update less, css and views for HumHub 1.14 (now min version)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ### A child theme for HumHub
 
-**Version: 0.6.0** (for HumHub 1.14)
+**Version: 0.6.1** (for HumHub 1.14)
 
 This is a child [theme module](https://docs.humhub.org/docs/theme/module#theme-module), the changes compared to the community theme are listed below.
 

--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
 	"id": "theme-orange",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"name": "Orange Theme",
 	"description": "A child theme for HumHub",
 	"humhub": {


### PR DESCRIPTION
The theme was always selected when another module was enabled. The theme settings were lost because the default settings were saved again.